### PR TITLE
Fix lives gui exception thrown on level 2

### DIFF
--- a/unityfiles/Assets/Scripts/GUI/LivesGUI.cs
+++ b/unityfiles/Assets/Scripts/GUI/LivesGUI.cs
@@ -25,6 +25,10 @@ public class LivesGUI : MonoBehaviour {
         }
     }
 
+    private void OnDestroy() {
+        PlayerHealthController.OnPlayerLivesUpdate -= CallbackOnLivesUpdate;
+    }
+
     private void CallbackOnLivesUpdate(object _, PlayerLivesUpdateArgs args) {
         if (!initialized) {
             GenerateLifeObject(args.CurrentLives);


### PR DESCRIPTION
Fixes exception thrown when getting into level 2 after letter game. This was caused by not unsubscribing from an event.